### PR TITLE
Allow for out-of-order TLS Handshake processing and partial outputs

### DIFF
--- a/d4tls/fingerprinter.go
+++ b/d4tls/fingerprinter.go
@@ -49,6 +49,7 @@ func (t *TLSSession) d4fg() string {
 
 func (t *TLSSession) ja3s() bool {
 	var buf []byte
+
 	buf = strconv.AppendInt(buf, int64(t.handShakeRecord.ETLSHandshakeServerHello.Vers), 10)
 	// byte (44) is ","
 	buf = append(buf, byte(44))
@@ -81,6 +82,7 @@ func (t *TLSSession) ja3s() bool {
 
 func (t *TLSSession) ja3() bool {
 	var buf []byte
+
 	buf = strconv.AppendInt(buf, int64(t.handShakeRecord.ETLSHandshakeClientHello.Vers), 10)
 	// byte (44) is ","
 	buf = append(buf, byte(44))

--- a/d4tls/fingerprinter_test.go
+++ b/d4tls/fingerprinter_test.go
@@ -203,7 +203,8 @@ func TestJA3(t *testing.T) {
 			for _, etlsrecord := range tls.Handshake {
 				if etlsrecord.ETLSHandshakeMsgType == 1 {
 					// Populate Client Hello related fields
-					tlss.PopulateClientHello(etlsrecord.ETLSHandshakeClientHello, "", "", "", "", time.Now())
+					tlss.PopulateClientHello(etlsrecord.ETLSHandshakeClientHello)
+					tlss.SetTimestamp(time.Now())
 					tlss.D4Fingerprinting("ja3")
 					t.Logf("%v", tlss.Record.JA3)
 					t.Logf("%v", tlss.Record.JA3Digest)
@@ -279,7 +280,8 @@ func TestGreaseClientHelloExtensionExlusion(t *testing.T) {
 			for _, etlsrecord := range tls.Handshake {
 				if etlsrecord.ETLSHandshakeMsgType == 1 {
 					// Populate Client Hello related fields
-					tlss.PopulateClientHello(etlsrecord.ETLSHandshakeClientHello, "", "", "", "", time.Now())
+					tlss.PopulateClientHello(etlsrecord.ETLSHandshakeClientHello)
+					tlss.SetTimestamp(time.Now())
 					tlss.D4Fingerprinting("ja3")
 					t.Logf("%v", tlss.Record.JA3Digest)
 					if strings.Index(tlss.Record.JA3, "2570") != -1 {
@@ -312,7 +314,8 @@ func TestGreaseClientHelloCipherExlusion(t *testing.T) {
 			for _, etlsrecord := range tls.Handshake {
 				if etlsrecord.ETLSHandshakeMsgType == 1 {
 					// Populate Client Hello related fields
-					tlss.PopulateClientHello(etlsrecord.ETLSHandshakeClientHello, "", "", "", "", time.Now())
+					tlss.PopulateClientHello(etlsrecord.ETLSHandshakeClientHello)
+					tlss.SetTimestamp(time.Now())
 					tlss.D4Fingerprinting("ja3")
 					if strings.Index(tlss.Record.JA3, "2570") != -1 {
 						t.Logf("GREASE values should not end up in JA3\n")

--- a/d4tls/flags.go
+++ b/d4tls/flags.go
@@ -1,0 +1,19 @@
+package d4tls
+
+// HandshakeState is a flag which keeps record of which handeshake message types
+// have been parsed.
+type HandshakeState uint8
+
+const (
+	StateClientHello = 1 << iota
+	StateServerHello
+	StateCertificate
+)
+
+func (s *HandshakeState) Set(flag HandshakeState) {
+	*s |= flag
+}
+
+func (s HandshakeState) Has(flag HandshakeState) bool {
+	return s&flag != 0
+}


### PR DESCRIPTION
I want to resolve #7 by allowing for a more liberal parsing of the TLS Handshake. We set a flag for each of the three states:
* ClientHello
* ServerHello
* Certificate

If all three have been processed, we output the TLS session.

As an addition, we can specify an option partial which will also output TLS sessions where atleast one of ClientHello or ServerHello has been processed. This is called when the Stream is closed.